### PR TITLE
Added barebones support for multiple commands

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -132,10 +132,11 @@ def apply_patches():
 
 def run_command(command):
     # Run command
-    retcode = subprocess.check_call(command.split())
-    if retcode:
-        print(f'::error::Error while executing command "{command}"')
-        exit(1)
+    for subcommand in command.split(';'):
+        retcode = subprocess.check_call(subcommand.split())
+        if retcode:
+            print(f'::error::Error while executing command "{subcommand}"')
+            exit(1)
 
 
 def set_output(repository_root, workdir):


### PR DESCRIPTION
as described in readme, fixes #4

noting that neither before nor after this change did the code process quoted command arguments correctly.  using the `bash -c` approach provided by the subprocess module might make it easier, given everything is running in a container anyway.