### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ jobs:
 
         - name: Push binary to data branch
           if: github.event_name == 'push'
-          run: python master/.ci/move_binary.py "${{ steps.buildozer.outputs.filename }}" master data
+          run: python master/.ci/move_binary.py "${{ steps.buildozer.outputs.filename }}" master data bin
   ```
 </details>
 


### PR DESCRIPTION
Fix the `Full workflow with uploading binaries to branch` example. Add the `4th` argument to `run command` in the `Push binary to data branch` step. If copied as it is, it causes the `IndexOutOfRange Error`.