### PR TITLE
Fix buildozer deployment 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,17 @@ FROM kivy/buildozer:latest
 # This is needed to install version specified by user
 RUN pip3 uninstall -y buildozer
 
+# Update Cython as Buildozer now requires it to build successfully
+RUN pip install --upgrade Cython
+
+# Get the latest JDK version as Buildozer requires the latest version to build the APK
+RUN sudo apt-get update && \
+    sudo apt-get install -y software-properties-common && \
+    sudo rm -rf /var/lib/apt/lists/*
+RUN sudo add-apt-repository ppa:openjdk-r/ppa
+RUN sudo apt update
+RUN sudo apt-get -y install openjdk-17-jdk
+
 # Remove a lot of warnings
 # sudo: setrlimit(RLIMIT_CORE): Operation not permitted
 # See https://github.com/sudo-project/sudo/issues/42


### PR DESCRIPTION
When using buildozer-action as github action, two errors occured: ERROR: /github/workspace/MonalMobileCrashAnalyzer_Deploy/.buildozer/android/platform/build-armeabi-v7a/build/other_builds/hostpython3/desktop/hostpython3/native-build/python3 failed! and > Failed to apply plugin 'com.android.internal.application'. > Android Gradle plugin requires Java 17 to run. You are currently using Java 13. To fix that Cython and the newest java version was added.