### PR TITLE
Update entrypoint.py to use GITHUB_OUTPUT environment variable

### DIFF
--- a/entrypoint.py
+++ b/entrypoint.py
@@ -152,8 +152,8 @@ def set_output(repository_root, workdir):
     path = os.path.normpath(
         os.path.join(repository_root, workdir, "bin", filename)
     )
-    print(f"::set-output name=filename::{path}")
-
+    with open(os.environ["GITHUB_OUTPUT"], "a") as gofh:
+        print(f'filename={path}', file=gofh)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
set-output is deprecated and was replaced by the GITHUB_OUTPUT environment variable.

This fixes the following warning when using this action:

_The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/_
