### PR TITLE
Fix user `user` doesn't exist error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN echo "Set disable_coredump false" | sudo tee -a /etc/sudo.conf > /dev/null
 ENV PYTHONUNBUFFERED=1
 
 # Set up venv
-RUN virtualenv venv
-ENV VIRTUAL_ENV /venv
+RUN python3 -m venv venv
+ENV VIRTUAL_ENV=/venv
 ENV PATH=/venv/bin:$PATH
 
 # Set up entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ ENV PYTHONUNBUFFERED=1
 RUN python3 -m venv /home/user/.venv
 ENV VIRTUAL_ENV=/home/user/.venv
 ENV PATH=/home/user/.venv/bin:$PATH
-ENV BUILDOZER_BUILD_DIR="${GITHUB_WORKSPACE}/${INPUT_REPOSITORY_ROOT}/.buildozer_global"
+# ENV BUILDOZER_BUILD_DIR="${GITHUB_WORKSPACE}/${INPUT_REPOSITORY_ROOT}/.buildozer_global"  # vars not found
 
 # Install dependencies
 RUN python -m pip install setuptools

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ RUN python3 -m venv /home/user/.venv
 ENV VIRTUAL_ENV=/home/user/.venv
 ENV PATH=/home/user/.venv/bin:$PATH
 
+# Install dependencies
+RUN python -m pip install distutils
+
 # Set up entrypoint
 COPY entrypoint.py /action/entrypoint.py
 ENTRYPOINT ["/action/entrypoint.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ RUN echo "Set disable_coredump false" | sudo tee -a /etc/sudo.conf > /dev/null
 ENV PYTHONUNBUFFERED=1
 
 # Set up venv
-RUN python3 -m venv venv
-ENV VIRTUAL_ENV=/venv
-ENV PATH=/venv/bin:$PATH
+RUN python3 -m venv /home/user/.venv
+ENV VIRTUAL_ENV=/home/user/.venv
+ENV PATH=/home/user/.venv/bin:$PATH
 
 # Set up entrypoint
 COPY entrypoint.py /action/entrypoint.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,11 @@ RUN echo "Set disable_coredump false" | sudo tee -a /etc/sudo.conf > /dev/null
 # Set env variable to disable this behavior
 ENV PYTHONUNBUFFERED=1
 
-# Set up venv
+# Set up venv and env
 RUN python3 -m venv /home/user/.venv
 ENV VIRTUAL_ENV=/home/user/.venv
 ENV PATH=/home/user/.venv/bin:$PATH
+ENV BUILDOZER_BUILD_DIR="${GITHUB_WORKSPACE}/${INPUT_REPOSITORY_ROOT}/.buildozer_global"
 
 # Install dependencies
 RUN python -m pip install setuptools

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,11 @@ RUN echo "Set disable_coredump false" | sudo tee -a /etc/sudo.conf > /dev/null
 # Set env variable to disable this behavior
 ENV PYTHONUNBUFFERED=1
 
+# Set up venv
+RUN virtualenv venv
+ENV VIRTUAL_ENV /venv
+ENV PATH=/venv/bin:$PATH
+
+# Set up entrypoint
 COPY entrypoint.py /action/entrypoint.py
 ENTRYPOINT ["/action/entrypoint.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ ENV BUILDOZER_BUILD_DIR="./.buildozer"
 ENV BUILDOZER_BIN="./bin"
 
 # Install dependencies in venv
-#RUN python -m pip install setuptools
+RUN python -m pip install setuptools
 
 # Set up entrypoint
 COPY entrypoint.py /action/entrypoint.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV VIRTUAL_ENV=/home/user/.venv
 ENV PATH=/home/user/.venv/bin:$PATH
 
 # Install dependencies
-RUN python -m pip install distutils
+RUN python -m pip install setuptools
 
 # Set up entrypoint
 COPY entrypoint.py /action/entrypoint.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,6 @@ RUN echo "Set disable_coredump false" | sudo tee -a /etc/sudo.conf > /dev/null
 ENV PYTHONUNBUFFERED=1
 
 # Set up venv and env
-# GitHub sets HOME to /github/home, but Buildozer is installed to /home/user. Change HOME to user's home
-ENV HOME=$HOME_DIR
 # Set venv vars
 RUN python3 -m venv $HOME_DIR/.venv
 ENV VIRTUAL_ENV=$HOME_DIR/.venv
@@ -36,8 +34,8 @@ ENV APP_ANDROID_ACCEPT_SDK_LICENSE="1"
 ENV BUILDOZER_BUILD_DIR="./.buildozer"
 ENV BUILDOZER_BIN="./bin"
 
-# Install dependencies
-RUN python -m pip install setuptools
+# Install dependencies in venv
+#RUN python -m pip install setuptools
 
 # Set up entrypoint
 COPY entrypoint.py /action/entrypoint.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,18 @@ RUN echo "Set disable_coredump false" | sudo tee -a /etc/sudo.conf > /dev/null
 ENV PYTHONUNBUFFERED=1
 
 # Set up venv and env
-RUN python3 -m venv /home/user/.venv
-ENV VIRTUAL_ENV=/home/user/.venv
-ENV PATH=/home/user/.venv/bin:$PATH
-# ENV BUILDOZER_BUILD_DIR="${GITHUB_WORKSPACE}/${INPUT_REPOSITORY_ROOT}/.buildozer_global"  # vars not found
+# GitHub sets HOME to /github/home, but Buildozer is installed to /home/user. Change HOME to user's home
+ENV HOME=$HOME_DIR
+# Set venv vars
+RUN python3 -m venv $HOME_DIR/.venv
+ENV VIRTUAL_ENV=$HOME_DIR/.venv
+ENV PATH=$HOME_DIR/.venv/bin:$PATH
+# Buildozer settings to disable interactions
+ENV BUILDOZER_WARN_ON_ROOT="0"
+ENV APP_ANDROID_ACCEPT_SDK_LICENSE="1"
+# Do not allow to change directories
+ENV BUILDOZER_BUILD_DIR="./.buildozer"
+ENV BUILDOZER_BIN="./bin"
 
 # Install dependencies
 RUN python -m pip install setuptools

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -18,7 +18,6 @@ from os import environ as env
 
 
 def main():
-    # env["USER"] = "ubuntu"
     # repository_root = os.path.abspath(env["INPUT_REPOSITORY_ROOT"])
     # change_owner(env["USER"], repository_root)
     fix_home()
@@ -26,6 +25,9 @@ def main():
     apply_buildozer_settings()
     change_directory(env["INPUT_REPOSITORY_ROOT"], env["INPUT_WORKDIR"])
     # apply_patches()
+    env["BUILDOZER_BUILD_DIR"] = (
+        f"{env['GITHUB_WORKSPACE']}/{env['INPUT_REPOSITORY_ROOT']}/.buildozer_global"
+    )
     run_command(env["INPUT_COMMAND"])
     set_output(env["INPUT_REPOSITORY_ROOT"], env["INPUT_WORKDIR"])
     # change_owner("root", repository_root)

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -21,7 +21,7 @@ from pathlib import Path
 def main():
     # repository_root = os.path.abspath(env["INPUT_REPOSITORY_ROOT"])
     # change_owner(env["USER"], repository_root)
-    # fix_home()
+    fix_home()
     install_buildozer(env["INPUT_BUILDOZER_VERSION"])
     # apply_buildozer_settings()
     change_directory(env["INPUT_REPOSITORY_ROOT"], env["INPUT_WORKDIR"])

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -15,6 +15,7 @@ import subprocess
 
 # import sys
 from os import environ as env
+from pathlib import Path
 
 
 def main():
@@ -25,7 +26,7 @@ def main():
     apply_buildozer_settings()
     change_directory(env["INPUT_REPOSITORY_ROOT"], env["INPUT_WORKDIR"])
     # apply_patches()
-    set_build_env()
+    symlink_global_buildozer_dir()
     run_command(env["INPUT_COMMAND"])
     set_output(env["INPUT_REPOSITORY_ROOT"], env["INPUT_WORKDIR"])
     # change_owner("root", repository_root)
@@ -132,17 +133,20 @@ def apply_patches():
     print("::endgroup::")
 
 
-def set_build_env():
-    # Set build_dir
-    buildozer_global = (
+def symlink_global_buildozer_dir():
+    global_buildozer_dir = Path(
         f"{env['GITHUB_WORKSPACE']}/{env['INPUT_REPOSITORY_ROOT']}/.buildozer_global"
     )
-    env["BUILDOZER_BUILD_DIR"] = buildozer_global
-    # Set android platform dirs
-    # android_platform = f"{buildozer_global}/android/platform"
-    # env["APP_ANDROID_ANT_PATH"] = android_platform
-    # env["APP_ANDROID_NDK_PATH"] = android_platform
-    # env["APP_ANDROID_SDK_PATH"] = f"{android_platform}/android-sdk"
+    global_buildozer_dir.symlink_to(
+        f"{env['HOME']}/.buildozer", target_is_directory=True
+    )
+
+
+def set_buildozer_env():
+    # Set build_dir to GutHub runner
+    env["BUILDOZER_BUILD_DIR"] = (
+        f"{env['GITHUB_WORKSPACE']}/{env['INPUT_REPOSITORY_ROOT']}/.buildozer_global"
+    )
 
 
 def run_command(command):

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -21,9 +21,9 @@ from pathlib import Path
 def main():
     # repository_root = os.path.abspath(env["INPUT_REPOSITORY_ROOT"])
     # change_owner(env["USER"], repository_root)
-    fix_home()
+    # fix_home()
     install_buildozer(env["INPUT_BUILDOZER_VERSION"])
-    apply_buildozer_settings()
+    # apply_buildozer_settings()
     change_directory(env["INPUT_REPOSITORY_ROOT"], env["INPUT_WORKDIR"])
     # apply_patches()
     symlink_global_buildozer_dir()
@@ -140,6 +140,10 @@ def symlink_global_buildozer_dir():
     global_buildozer_dir.mkdir()
     default_buildozer_dir = Path(env["BUILDOZER_BUILD_DIR"]).resolve()
     default_buildozer_dir.symlink_to(global_buildozer_dir, target_is_directory=True)
+    for d in (global_buildozer_dir, default_buildozer_dir):
+        p = subprocess.run(["ls", "-a", "-l", str(d)])
+        print(f"{p.stdout=}")
+        print(f"{p.stderr=}")
 
 
 def set_buildozer_env():

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -138,12 +138,14 @@ def symlink_global_buildozer_dir():
         f"{env['GITHUB_WORKSPACE']}/{env['INPUT_REPOSITORY_ROOT']}/.buildozer_global"
     )
     global_buildozer_dir.mkdir()
-    default_buildozer_dir = Path(env["BUILDOZER_BUILD_DIR"]).resolve()
+    default_buildozer_dir = Path.home() / ".buildozer"
     default_buildozer_dir.symlink_to(global_buildozer_dir, target_is_directory=True)
     for d in (global_buildozer_dir, default_buildozer_dir):
         p = subprocess.run(["ls", "-a", "-l", str(d)], capture_output=True)
         print(f"{p.stdout=}")
         print(f"{p.stderr=}")
+    for k, v in sorted(env.items()):
+        print(f"{k}={v}")
 
 
 def set_buildozer_env():

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -139,10 +139,10 @@ def set_build_env():
     )
     env["BUILDOZER_BUILD_DIR"] = buildozer_global
     # Set android platform dirs
-    android_platform = f"{buildozer_global}/android/platform"
-    env["APP_ANDROID_ANT_PATH"] = android_platform
-    env["APP_ANDROID_NDK_PATH"] = android_platform
-    env["APP_ANDROID_SDK_PATH"] = f"{android_platform}/android-sdk"
+    # android_platform = f"{buildozer_global}/android/platform"
+    # env["APP_ANDROID_ANT_PATH"] = android_platform
+    # env["APP_ANDROID_NDK_PATH"] = android_platform
+    # env["APP_ANDROID_SDK_PATH"] = f"{android_platform}/android-sdk"
 
 
 def run_command(command):

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -142,7 +142,7 @@ def set_build_env():
     android_platform = f"{buildozer_global}/android/platform"
     env["APP_ANDROID_ANT_PATH"] = android_platform
     env["APP_ANDROID_NDK_PATH"] = android_platform
-    env["APP_ANDROID_SDK_PATH"] = android_platform
+    env["APP_ANDROID_SDK_PATH"] = f"{android_platform}/android-sdk"
 
 
 def run_command(command):

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -17,8 +17,9 @@ from os import environ as env
 
 
 def main():
-    # repository_root = os.path.abspath(env["INPUT_REPOSITORY_ROOT"])
-    # change_owner(env["USER"], repository_root)
+    env["USER"] = "ubuntu"
+    repository_root = os.path.abspath(env["INPUT_REPOSITORY_ROOT"])
+    change_owner(env["USER"], repository_root)
     fix_home()
     install_buildozer(env["INPUT_BUILDOZER_VERSION"])
     apply_buildozer_settings()
@@ -26,7 +27,7 @@ def main():
     apply_patches()
     run_command(env["INPUT_COMMAND"])
     set_output(env["INPUT_REPOSITORY_ROOT"], env["INPUT_WORKDIR"])
-    # change_owner("root", repository_root)
+    change_owner("root", repository_root)
 
 
 def change_owner(user, repository_root):
@@ -43,10 +44,7 @@ def fix_home():
 def install_buildozer(buildozer_version):
     # Install required Buildozer version
     print("::group::Installing Buildozer")
-    # pip_install = [sys.executable] + "-m pip install --user --upgrade".split()
-    pip_install = [
-        sys.executable
-    ] + "-m pip install --break-system-packages --upgrade".split()
+    pip_install = [sys.executable] + "-m pip install --user --upgrade".split()
     if buildozer_version == "stable":
         # Install stable buildozer from PyPI
         subprocess.check_call([*pip_install, "buildozer"])

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -141,7 +141,7 @@ def symlink_global_buildozer_dir():
     default_buildozer_dir = Path(env["BUILDOZER_BUILD_DIR"]).resolve()
     default_buildozer_dir.symlink_to(global_buildozer_dir, target_is_directory=True)
     for d in (global_buildozer_dir, default_buildozer_dir):
-        p = subprocess.run(["ls", "-a", "-l", str(d)])
+        p = subprocess.run(["ls", "-a", "-l", str(d)], capture_output=True)
         print(f"{p.stdout=}")
         print(f"{p.stderr=}")
 

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -18,9 +18,9 @@ from os import environ as env
 
 
 def main():
-    env["USER"] = "ubuntu"
-    repository_root = os.path.abspath(env["INPUT_REPOSITORY_ROOT"])
-    change_owner(env["USER"], repository_root)
+    # env["USER"] = "ubuntu"
+    # repository_root = os.path.abspath(env["INPUT_REPOSITORY_ROOT"])
+    # change_owner(env["USER"], repository_root)
     fix_home()
     install_buildozer(env["INPUT_BUILDOZER_VERSION"])
     apply_buildozer_settings()
@@ -28,7 +28,7 @@ def main():
     apply_patches()
     run_command(env["INPUT_COMMAND"])
     set_output(env["INPUT_REPOSITORY_ROOT"], env["INPUT_WORKDIR"])
-    change_owner("root", repository_root)
+    # change_owner("root", repository_root)
 
 
 def change_owner(user, repository_root):

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -85,7 +85,7 @@ def symlink_global_buildozer_dir():
     print(
         f"::group::Creating symlink from {global_buildozer_dir} to {default_buildozer_dir}."
     )
-    global_buildozer_dir.mkdir()
+    global_buildozer_dir.mkdir(exist_ok=True)
     default_buildozer_dir.symlink_to(global_buildozer_dir, target_is_directory=True)
     print("::endgroup::")
 

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -26,7 +26,7 @@ def main():
     run_command(env["INPUT_COMMAND"])
     set_output(env["INPUT_REPOSITORY_ROOT"], env["INPUT_WORKDIR"])
     show_env()
-    show_buildozer_global_dir()
+    show_buildozer_dirs()
 
 
 def fix_home():
@@ -76,8 +76,8 @@ def change_directory(repository_root, workdir):
 
 
 def symlink_global_buildozer_dir():
-    env["BUILDOZER_DEFAULT"] = f"{env['HOME']}/.buildozer"
-    env["BUILDOZER_GLOBAL"] = (
+    env["BUILDOZER_DEFAULT_DIR"] = f"{env['HOME']}/.buildozer"
+    env["BUILDOZER_GLOBAL_DIR"] = (
         f"{env['GITHUB_WORKSPACE']}/{env['INPUT_REPOSITORY_ROOT']}/.buildozer_global"
     )
     global_buildozer_dir = Path(env["BUILDOZER_GLOBAL_DIR"])
@@ -124,10 +124,12 @@ def show_env():
     print("::endgroup::")
 
 
-def show_buildozer_global_dir():
-    print("::group::Showing BUILDOZER_GLOBAL_DIR contents.")
-    for f in Path(env["BUILDOZER_GLOBAL_DIR"]).iterdir():
-        print(f)
+def show_buildozer_dirs():
+    print("::group::Showing BUILDOZER_DEFAULT_DIR & BUILDOZER_GLOBAL_DIR contents.")
+    for d in (env["BUILDOZER_DEFAULT_DIR"], env["BUILDOZER_GLOBAL_DIR"]):
+        print(f"{d}:")
+        for f in Path(d).iterdir():
+            print(f)
     print("::endgroup::")
 
 

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -43,7 +43,10 @@ def fix_home():
 def install_buildozer(buildozer_version):
     # Install required Buildozer version
     print("::group::Installing Buildozer")
-    pip_install = [sys.executable] + "-m pip install --user --upgrade".split()
+    # pip_install = [sys.executable] + "-m pip install --user --upgrade".split()
+    pip_install = [
+        sys.executable
+    ] + "-m pip install --break-system-packages --upgrade".split()
     if buildozer_version == "stable":
         # Install stable buildozer from PyPI
         subprocess.check_call([*pip_install, "buildozer"])

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -12,6 +12,7 @@ order.
 
 import os
 import subprocess
+
 # import sys
 from os import environ as env
 
@@ -44,7 +45,7 @@ def fix_home():
 def install_buildozer(buildozer_version):
     # Install required Buildozer version
     print("::group::Installing Buildozer")
-    pip_install = "python -m pip install --user --upgrade".split()
+    pip_install = "python -m pip install --upgrade".split()
     if buildozer_version == "stable":
         # Install stable buildozer from PyPI
         subprocess.check_call([*pip_install, "buildozer"])

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -25,7 +25,7 @@ def main():
     install_buildozer(env["INPUT_BUILDOZER_VERSION"])
     apply_buildozer_settings()
     change_directory(env["INPUT_REPOSITORY_ROOT"], env["INPUT_WORKDIR"])
-    apply_patches()
+    # apply_patches()
     run_command(env["INPUT_COMMAND"])
     set_output(env["INPUT_REPOSITORY_ROOT"], env["INPUT_WORKDIR"])
     # change_owner("root", repository_root)

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -19,23 +19,14 @@ from pathlib import Path
 
 
 def main():
-    # repository_root = os.path.abspath(env["INPUT_REPOSITORY_ROOT"])
-    # change_owner(env["USER"], repository_root)
     fix_home()
     install_buildozer(env["INPUT_BUILDOZER_VERSION"])
-    # apply_buildozer_settings()
     change_directory(env["INPUT_REPOSITORY_ROOT"], env["INPUT_WORKDIR"])
-    # apply_patches()
     symlink_global_buildozer_dir()
     run_command(env["INPUT_COMMAND"])
     set_output(env["INPUT_REPOSITORY_ROOT"], env["INPUT_WORKDIR"])
-    # change_owner("root", repository_root)
-
-
-def change_owner(user, repository_root):
-    # GitHub sets root as owner of repository directory. Change it to user
-    # And return to root after all commands
-    subprocess.check_call(["sudo", "chown", "-R", user, repository_root])
+    show_env()
+    show_buildozer_global_dir()
 
 
 def fix_home():
@@ -75,15 +66,6 @@ def install_buildozer(buildozer_version):
     print("::endgroup::")
 
 
-def apply_buildozer_settings():
-    # Buildozer settings to disable interactions
-    env["BUILDOZER_WARN_ON_ROOT"] = "0"
-    env["APP_ANDROID_ACCEPT_SDK_LICENSE"] = "1"
-    # Do not allow to change directories
-    env["BUILDOZER_BUILD_DIR"] = "./.buildozer"
-    env["BUILDOZER_BIN"] = "./bin"
-
-
 def change_directory(repository_root, workdir):
     directory = os.path.join(repository_root, workdir)
     # Change directory to workir
@@ -93,66 +75,19 @@ def change_directory(repository_root, workdir):
     os.chdir(directory)
 
 
-def apply_patches():
-    # Apply patches
-    print("::group::Applying patches to Buildozer")
-    try:
-        import importlib
-        import site
-
-        importlib.reload(site)
-        globals()["buildozer"] = importlib.import_module("buildozer")
-    except ImportError:
-        print(
-            "::error::Cannot apply patches to buildozer (ImportError). "
-            "Update buildozer-action to new version or create a Bug Request"
-        )
-        print("::endgroup::")
-        return
-
-    print("Changing global_buildozer_dir")
-    source = open(buildozer.__file__, "r", encoding="utf-8").read()
-    new_source = source.replace(
-        """
-    @property
-    def global_buildozer_dir(self):
-        return join(expanduser('~'), '.buildozer')
-""",
-        f"""
-    @property
-    def global_buildozer_dir(self):
-        return '{env["GITHUB_WORKSPACE"]}/{env["INPUT_REPOSITORY_ROOT"]}/.buildozer_global'
-""",
-    )
-    if new_source == source:
-        print(
-            "::warning::Cannot change global buildozer directory. "
-            "Update buildozer-action to new version or create a Bug Request"
-        )
-    open(buildozer.__file__, "w", encoding="utf-8").write(new_source)
-    print("::endgroup::")
-
-
 def symlink_global_buildozer_dir():
-    global_buildozer_dir = Path(
+    env["BUILDOZER_DEFAULT"] = f"{env['HOME']}/.buildozer"
+    env["BUILDOZER_GLOBAL"] = (
         f"{env['GITHUB_WORKSPACE']}/{env['INPUT_REPOSITORY_ROOT']}/.buildozer_global"
+    )
+    global_buildozer_dir = Path(env["BUILDOZER_GLOBAL_DIR"])
+    default_buildozer_dir = Path(env["BUILDOZER_DEFAULT_DIR"])
+    print(
+        f"::group::Creating symlink from {global_buildozer_dir} to {default_buildozer_dir}."
     )
     global_buildozer_dir.mkdir()
-    default_buildozer_dir = Path.home() / ".buildozer"
     default_buildozer_dir.symlink_to(global_buildozer_dir, target_is_directory=True)
-    for d in (global_buildozer_dir, default_buildozer_dir):
-        p = subprocess.run(["ls", "-a", "-l", str(d)], capture_output=True)
-        print(f"{p.stdout=}")
-        print(f"{p.stderr=}")
-    for k, v in sorted(env.items()):
-        print(f"{k}={v}")
-
-
-def set_buildozer_env():
-    # Set build_dir to GutHub runner
-    env["BUILDOZER_BUILD_DIR"] = (
-        f"{env['GITHUB_WORKSPACE']}/{env['INPUT_REPOSITORY_ROOT']}/.buildozer_global"
-    )
+    print("::endgroup::")
 
 
 def run_command(command):
@@ -180,6 +115,20 @@ def set_output(repository_root, workdir):
             f"echo 'filename={path}' >> {os.environ['GITHUB_OUTPUT']}",
         ]
     )
+
+
+def show_env():
+    print("::group::Showing env variables.")
+    for k, v in sorted(env.items()):
+        print(f"{k}={v}")
+    print("::endgroup::")
+
+
+def show_buildozer_global_dir():
+    print("::group::Showing BUILDOZER_GLOBAL_DIR contents.")
+    for f in Path(env["BUILDOZER_GLOBAL_DIR"]).iterdir():
+        print(f)
+    print("::endgroup::")
 
 
 if __name__ == "__main__":

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -12,7 +12,7 @@ order.
 
 import os
 import subprocess
-import sys
+# import sys
 from os import environ as env
 
 
@@ -44,7 +44,7 @@ def fix_home():
 def install_buildozer(buildozer_version):
     # Install required Buildozer version
     print("::group::Installing Buildozer")
-    pip_install = [sys.executable] + "-m pip install --user --upgrade".split()
+    pip_install = "python -m pip install --user --upgrade".split()
     if buildozer_version == "stable":
         # Install stable buildozer from PyPI
         subprocess.check_call([*pip_install, "buildozer"])

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -137,9 +137,9 @@ def symlink_global_buildozer_dir():
     global_buildozer_dir = Path(
         f"{env['GITHUB_WORKSPACE']}/{env['INPUT_REPOSITORY_ROOT']}/.buildozer_global"
     )
-    global_buildozer_dir.symlink_to(
-        f"{env['HOME']}/.buildozer", target_is_directory=True
-    )
+    global_buildozer_dir.mkdir()
+    default_buildozer_dir = Path(env["BUILDOZER_BUILD_DIR"]).resolve()
+    default_buildozer_dir.symlink_to(global_buildozer_dir, target_is_directory=True)
 
 
 def set_buildozer_env():

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -25,9 +25,7 @@ def main():
     apply_buildozer_settings()
     change_directory(env["INPUT_REPOSITORY_ROOT"], env["INPUT_WORKDIR"])
     # apply_patches()
-    env["BUILDOZER_BUILD_DIR"] = (
-        f"{env['GITHUB_WORKSPACE']}/{env['INPUT_REPOSITORY_ROOT']}/.buildozer_global"
-    )
+    set_build_env()
     run_command(env["INPUT_COMMAND"])
     set_output(env["INPUT_REPOSITORY_ROOT"], env["INPUT_WORKDIR"])
     # change_owner("root", repository_root)
@@ -132,6 +130,19 @@ def apply_patches():
         )
     open(buildozer.__file__, "w", encoding="utf-8").write(new_source)
     print("::endgroup::")
+
+
+def set_build_env():
+    # Set build_dir
+    buildozer_global = (
+        f"{env['GITHUB_WORKSPACE']}/{env['INPUT_REPOSITORY_ROOT']}/.buildozer_global"
+    )
+    env["BUILDOZER_BUILD_DIR"] = buildozer_global
+    # Set android platform dirs
+    android_platform = f"{buildozer_global}/android/platform"
+    env["APP_ANDROID_ANT_PATH"] = android_platform
+    env["APP_ANDROID_NDK_PATH"] = android_platform
+    env["APP_ANDROID_SDK_PATH"] = android_platform
 
 
 def run_command(command):

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -17,8 +17,8 @@ from os import environ as env
 
 
 def main():
-    repository_root = os.path.abspath(env["INPUT_REPOSITORY_ROOT"])
-    change_owner(env["USER"], repository_root)
+    # repository_root = os.path.abspath(env["INPUT_REPOSITORY_ROOT"])
+    # change_owner(env["USER"], repository_root)
     fix_home()
     install_buildozer(env["INPUT_BUILDOZER_VERSION"])
     apply_buildozer_settings()
@@ -26,7 +26,7 @@ def main():
     apply_patches()
     run_command(env["INPUT_COMMAND"])
     set_output(env["INPUT_REPOSITORY_ROOT"], env["INPUT_WORKDIR"])
-    change_owner("root", repository_root)
+    # change_owner("root", repository_root)
 
 
 def change_owner(user, repository_root):
@@ -140,18 +140,12 @@ def run_command(command):
 
 def set_output(repository_root, workdir):
     if not os.path.exists("bin"):
-        print(
-            "::error::Output directory does not exist. See Buildozer log for error"
-        )
+        print("::error::Output directory does not exist. See Buildozer log for error")
         exit(1)
     filename = [
-        file
-        for file in os.listdir("bin")
-        if os.path.isfile(os.path.join("bin", file))
+        file for file in os.listdir("bin") if os.path.isfile(os.path.join("bin", file))
     ][0]
-    path = os.path.normpath(
-        os.path.join(repository_root, workdir, "bin", filename)
-    )
+    path = os.path.normpath(os.path.join(repository_root, workdir, "bin", filename))
     # Run with sudo to have access to GITHUB_OUTPUT file
     subprocess.check_call(
         [


### PR DESCRIPTION
Fix #42 
- set up python virtual env in Dockerfile to avoid "externally managed environment" error
- skip trying to `chown` files to non-existent user `user`
- set buildozer vars in Dockerfile to simplify `entrypoint.py`
- use symlink to save `.buildozer` contents to `/github/workflow/.buildozer_global` rather than patch python code
- install buildozer in virtual env

There are a zillion commits here--feel free to squash them if you choose to merge them in.